### PR TITLE
Sets max width of snackbardBox to screen width

### DIFF
--- a/src/snackbard.vue
+++ b/src/snackbard.vue
@@ -181,7 +181,7 @@ export default {
   display: inline-flex;
   align-items: center;
   min-width: 250px;
-  max-width: 500px;
+  max-width: 100vw;
   max-height: 80px;
   padding: 14px 24px;
   display: grid;


### PR DESCRIPTION
Allows the snackbard box to change its width based on screen size. Helpful when using on a phone with a longer message.